### PR TITLE
Personal OA Support (add instant reply mode when OA is not register by organization)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ function envOptions (): Partial<PuppetOAOptions> {
     port            : process.env.WECHATY_PUPPET_OA_PORT ? parseInt(process.env.WECHATY_PUPPET_OA_PORT) : undefined,
     token           : process.env.WECHATY_PUPPET_OA_TOKEN,
     webhookProxyUrl : process.env.WECHATY_PUPPET_OA_WEBHOOK_PROXY_URL,
+    personalMode    : !!process.env.WECHATY_PUPPET_OA_PERSONAL_MODE,
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,9 +14,9 @@ function envOptions (): Partial<PuppetOAOptions> {
   return {
     appId           : process.env.WECHATY_PUPPET_OA_APP_ID,
     appSecret       : process.env.WECHATY_PUPPET_OA_APP_SECRET,
+    personalMode    : !!process.env.WECHATY_PUPPET_OA_PERSONAL_MODE,
     port            : process.env.WECHATY_PUPPET_OA_PORT ? parseInt(process.env.WECHATY_PUPPET_OA_PORT) : undefined,
     token           : process.env.WECHATY_PUPPET_OA_TOKEN,
-    personalMode    : !!process.env.WECHATY_PUPPET_OA_PERSONAL_MODE,
     webhookProxyUrl : process.env.WECHATY_PUPPET_OA_WEBHOOK_PROXY_URL,
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,8 @@ function envOptions (): Partial<PuppetOAOptions> {
     appSecret       : process.env.WECHATY_PUPPET_OA_APP_SECRET,
     port            : process.env.WECHATY_PUPPET_OA_PORT ? parseInt(process.env.WECHATY_PUPPET_OA_PORT) : undefined,
     token           : process.env.WECHATY_PUPPET_OA_TOKEN,
-    webhookProxyUrl : process.env.WECHATY_PUPPET_OA_WEBHOOK_PROXY_URL,
     personalMode    : !!process.env.WECHATY_PUPPET_OA_PERSONAL_MODE,
+    webhookProxyUrl : process.env.WECHATY_PUPPET_OA_WEBHOOK_PROXY_URL,
   }
 }
 

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -84,6 +84,7 @@ class OfficialAccount extends EventEmitter {
     log.verbose('OfficialAccount', 'constructor(%s)', JSON.stringify(options))
 
     this.webhook = new Webhook({
+      personalMode: !!this.options.personalMode,
       port: this.options.port,
       verify: this.verify.bind(this),
       webhookProxyUrl: this.options.webhookProxyUrl,

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -23,6 +23,7 @@ export interface OfficialAccountOptions {
   port?            : number,
   token            : string,
   webhookProxyUrl? : string,
+  personalMode?    : boolean,
 }
 
 interface AccessToken {
@@ -176,6 +177,14 @@ class OfficialAccount extends EventEmitter {
     } finally {
       this._accessTokenUpdating = false
     }
+  }
+
+  async sendCustomMessagePersonal (args: {
+    touser: string,
+    msgtype: OAMessageType,
+    content: string,
+  }) {
+    this.webhook.emit('instantReply', args)
   }
 
   /**

--- a/src/official-account/webhook.ts
+++ b/src/official-account/webhook.ts
@@ -226,7 +226,7 @@ class Webhook extends WebhookEventEmitter {
             resolve(msg.content)
           }
         })
-      })
+      }),
     ])
     if (reply) {
       return res.end(`

--- a/src/official-account/webhook.ts
+++ b/src/official-account/webhook.ts
@@ -216,7 +216,7 @@ class Webhook extends WebhookEventEmitter {
       'text',
       'image',
     ]
-    
+
     this.userOpen[payload.FromUserName] = true
     /**
      * TODO: support more MsgType
@@ -236,7 +236,7 @@ class Webhook extends WebhookEventEmitter {
     if (this.personalMode) {
       let reply: string|null = null
       const timeout = async (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-      for (let i = 0; i < (4000 / 5); i ++) {
+      for (let i = 0; i < (4000 / 5); i++) {
         await timeout(5)
         if (this.messageCache[payload.FromUserName]) {
           const msg: any = this.messageCache[payload.FromUserName]

--- a/src/official-account/webhook.ts
+++ b/src/official-account/webhook.ts
@@ -209,7 +209,6 @@ class Webhook extends WebhookEventEmitter {
     if (knownTypeList.includes(payload.MsgType)) {
       this.emit('message', payload)
     }
-    // console.info(payload)
 
     /**
      * 假如服务器无法保证在五秒内处理并回复，必须做出下述回复，这样微信服务器才不会对此作任何处理，
@@ -234,7 +233,7 @@ class Webhook extends WebhookEventEmitter {
               msgtype: OAMessageType,
               content: string,
             }) => {
-            if (msg.touser !== payload.ToUserName) {
+            if (msg.touser !== payload.FromUserName) {
               return
             }
             if (isTimeout) {

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -130,6 +130,7 @@ class PuppetOA extends Puppet {
       const oa = new OfficialAccount({
         appId           : this.appId,
         appSecret       : this.appSecret,
+        personalMode    : this.personalMode,
         port            : this.port,
         token           : this.token,
         webhookProxyUrl : this.webhookProxyUrl,

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -66,6 +66,7 @@ class PuppetOA extends Puppet {
   protected port?            : number
   protected token            : string
   protected webhookProxyUrl? : string
+  protected personalMode?    : boolean
 
   protected oa?: OfficialAccount
 
@@ -102,6 +103,12 @@ class PuppetOA extends Puppet {
       throw new Error(`
         PuppetOA: token not found. Please either set WECHATY_PUPPET_OA_TOKEN environment variabnle, or set 'token' options for PuppetOA.
       `)
+    }
+
+    if (options.personalMode) {
+      this.personalMode = options.personalMode
+    } else {
+      this.personalMode = false
     }
 
     this.port            = options.port
@@ -387,7 +394,11 @@ class PuppetOA extends Puppet {
         msgtype: 'text' as const,
         touser: conversationId,
       }
-      await this.oa?.sendCustomMessage(payload)
+      if (this.personalMode) {
+        await this.oa?.sendCustomMessagePersonal(payload)
+      } else {
+        await this.oa?.sendCustomMessage(payload)
+      }
     }
 
   }


### PR DESCRIPTION
Personal OA only support instant message reply in webhooks

I have add a event and listener in webhooks to reply instantly.

and an Environment tag WECHATY_PUPPET_OA_PERSONAL_MODE to specific running on instant mode.