### PR TITLE
add ready&login event emit  and make global pr runtime test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/src/official-account/official-account.spec.ts
+++ b/src/official-account/official-account.spec.ts
@@ -11,10 +11,16 @@ const ciInfo = require('ci-info')
 
 const unirest = require('unirest')
 
+/*
+ * refer to : https://github.com/wechaty/wechaty-puppet-official-account/issues/8
+ * try to fix global pr runtime test
+ */
+const isPR: boolean = ciInfo.isPR
+
 void cuid // for testing
 
 test('OfficialAccount smoke testing', async (t) => {
-  if (ciInfo.isPR) {
+  if (isPR) {
     t.skip('Skip for PR')
     return
   }
@@ -78,7 +84,7 @@ test('OfficialAccount smoke testing', async (t) => {
 })
 
 test('updateAccessToken()', async t => {
-  if (ciInfo.isPR) {
+  if (isPR) {
     t.skip('Skip for PR')
     return
   }
@@ -100,7 +106,7 @@ test('updateAccessToken()', async t => {
 })
 
 test('sendCustomMessage()', async t => {
-  if (ciInfo.isPR) {
+  if (isPR) {
     t.skip('Skip for PR')
     return
   }

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -112,7 +112,7 @@ class OfficialAccount extends EventEmitter {
     this.stopperFnList.push(stopper)
 
     await this.webhook.start()
-    
+
     // emit login & ready event
     this.emit('login')
     this.emit('ready')

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -112,6 +112,10 @@ class OfficialAccount extends EventEmitter {
     this.stopperFnList.push(stopper)
 
     await this.webhook.start()
+    
+    // emit login & ready event
+    this.emit('login')
+    this.emit('ready')
   }
 
   async stop () {

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -165,11 +165,13 @@ class PuppetOA extends Puppet {
       log.error('PuppetOA', 'start() rejection: %s', e)
       this.state.off(true)
     }
-
   }
 
   protected bridgeEvents (oa: OfficialAccount) {
     oa.on('message', msg => this.emit('message', { messageId: msg.MsgId }))
+    oa.on('login', _ => this.emit('login', { contactId: this.id || '' }))
+    oa.on('ready', _ => this.emit('ready', { data: 'ready' }))
+    oa.on('logout', _ => this.emit('logout', { contactId: this.id || '', data: 'logout' }))
   }
 
   public async stop (): Promise<void> {
@@ -193,11 +195,11 @@ class PuppetOA extends Puppet {
     } finally {
       this.state.off(true)
     }
-
   }
 
   public login (contactId: string): Promise<void> {
     log.verbose('PuppetOA', 'login()')
+    // developer can set contactId
     return super.login(contactId)
   }
 
@@ -212,6 +214,7 @@ class PuppetOA extends Puppet {
     this.id = undefined
 
     // TODO: do the logout job
+    await this.oa?.stop()
   }
 
   public ding (data?: string): void {


### PR DESCRIPTION
To my cons, there are some basic events for puppet which is important for developer.  So , `login`, `ready` and `logout` events are required for oa-puppet.

Due to the runtime pr enviroment test, `Build` Step in [`github actions`](https://github.com/wechaty/wechaty-puppet-official-account/runs/1308782369?check_suite_focus=true)  have not passed, so it can't be deployed to npm registry. 