### PR TITLE
fix login event contact user info error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/src/official-account/normalize-file-box.ts
+++ b/src/official-account/normalize-file-box.ts
@@ -4,7 +4,7 @@ import {
 }               from 'file-box'
 import {
   log,
-}               from 'wechaty'
+}               from 'wechaty-puppet'
 
 import {
   FileInfo,

--- a/src/official-account/schema.ts
+++ b/src/official-account/schema.ts
@@ -11,12 +11,14 @@ export type OAMessageType = 'text'
 export type OAMediaType = 'image' | 'voice' | 'video' | 'thumb'
 
 export interface OAMessagePayload {
-  ToUserName   : string
-  FromUserName : string
-  CreateTime   : string
-  MsgType      : OAMessageType
-  Content      : string
-  MsgId        : string
+  ToUserName  : string
+  FromUserName: string
+  CreateTime  : string
+  MsgType     : OAMessageType
+  MsgId       : string
+  Content?    : string
+  PicUrl?     : string
+  MediaId?    : string
 }
 
 /* eslint-disable camelcase */


### PR DESCRIPTION
When the puppet emit `login` event to wechaty, there is no contact user info, which will cause many upstream application has no condition info to start.  