### PR TITLE
payload should have id field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -155,7 +155,7 @@ class PuppetOA extends Puppet {
       // FIXME: Huan(202008) find a way to get the bot user information
       // set gh_ prefix to identify the official-account
       this.id = 'gh_wechaty-puppet-official-account'
-      await this.oa.payloadStore.setContactPayload(this.id, {} as any)
+      await this.oa.payloadStore.setContactPayload(this.id, { openid: this.id } as any)
 
       this.bridgeEvents(this.oa)
 


### PR DESCRIPTION
Below is the source code:
```typescript
await this.oa.payloadStore.setContactPayload(this.id, { } as any)
```

It save empty object as `ContactPayload`, which will cause `id not found` error. 

> `id` is the required field for payload