### PR TITLE
add batch official-account interface to puppet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/src/official-account/normalize-file-box.ts
+++ b/src/official-account/normalize-file-box.ts
@@ -16,7 +16,7 @@ const normalizeFileBox = async (fileBox: FileBox): Promise<{ buf: Buffer, info: 
     fileBox.name,
   )
 
-  const buf = await fileBox.toBuffer()
+  const buf    = await fileBox.toBuffer()
   const length = buf.byteLength
 
   const info: FileInfo = {

--- a/src/official-account/official-account.spec.ts
+++ b/src/official-account/official-account.spec.ts
@@ -124,8 +124,7 @@ test('sendCustomMessage()', async t => {
       msgtype: 'text',
       touser: 'ooEEu1Pdb4otFUedqOx_LP1p8sSQ',
     })
-    // console.info(ret)
-    t.equal(ret.errcode, 0, 'should get errcode 0')
+    t.isNot(ret, null, 'should get messageId')
   } catch (e) {
     t.fail('should not be rejected')
   } finally {

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -29,33 +29,33 @@ import {
 import { getTimeStampString } from './utils'
 
 export interface OfficialAccountOptions {
-  appId: string,
-  appSecret: string,
-  port?: number,
-  token: string,
-  webhookProxyUrl?: string,
-  personalMode?: boolean,
+  appId             : string,
+  appSecret         : string,
+  port?             : number,
+  token             : string,
+  webhookProxyUrl?  : string,
+  personalMode?     : boolean,
 }
 
 export interface AccessTokenPayload {
-  expiresIn: number,
-  timestamp: number,
-  token: string,
+  expiresIn : number,
+  timestamp : number,
+  token     : string,
 }
 
 type StopperFn = () => void
 
 class OfficialAccount extends EventEmitter {
 
-  payloadStore: PayloadStore
+  payloadStore                  : PayloadStore
 
-  protected webhook: Webhook
-  protected simpleUnirest: SimpleUnirest
+  protected webhook             : Webhook
+  protected simpleUnirest       : SimpleUnirest
 
-  protected accessTokenPayload?: AccessTokenPayload
+  protected accessTokenPayload? : AccessTokenPayload
 
-  protected stopperFnList: StopperFn[]
-  protected oaId: string
+  protected stopperFnList       : StopperFn[]
+  protected oaId                : string
 
   get accessToken (): string {
     if (!this.accessTokenPayload) {

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -1,8 +1,9 @@
 /* eslint-disable camelcase */
 import { EventEmitter } from 'events'
+import { v4 } from 'uuid'
 
 import crypto from 'crypto'
-import { ContactGender, FileBox, log }  from 'wechaty-puppet'
+import { ContactGender, FileBox, log } from 'wechaty-puppet'
 import { FileBoxType } from 'file-box'
 
 import { normalizeFileBox } from './normalize-file-box'
@@ -10,33 +11,36 @@ import { normalizeFileBox } from './normalize-file-box'
 import {
   Webhook,
   VerifyArgs,
-}                      from './webhook'
+} from './webhook'
 import { PayloadStore } from './payload-store'
 import {
   getSimpleUnirest,
   SimpleUnirest,
-}                       from './simple-unirest'
+} from './simple-unirest'
 import {
   OAMessageType,
   // OAMediaPayload,
   OAMediaType,
   ErrorPayload,
   OAContactPayload,
-}                       from './schema'
+  OATagPayload,
+  OAMessagePayload,
+} from './schema'
+import { getTimeStampString } from './utils'
 
 export interface OfficialAccountOptions {
-  appId            : string,
-  appSecret        : string,
-  port?            : number,
-  token            : string,
-  webhookProxyUrl? : string,
-  personalMode?    : boolean,
+  appId: string,
+  appSecret: string,
+  port?: number,
+  token: string,
+  webhookProxyUrl?: string,
+  personalMode?: boolean,
 }
 
 export interface AccessTokenPayload {
-  expiresIn : number,
-  timestamp : number,
-  token     : string,
+  expiresIn: number,
+  timestamp: number,
+  token: string,
 }
 
 type StopperFn = () => void
@@ -45,12 +49,13 @@ class OfficialAccount extends EventEmitter {
 
   payloadStore: PayloadStore
 
-  protected webhook       : Webhook
-  protected simpleUnirest : SimpleUnirest
+  protected webhook: Webhook
+  protected simpleUnirest: SimpleUnirest
 
-  protected accessTokenPayload?  : AccessTokenPayload
+  protected accessTokenPayload?: AccessTokenPayload
 
   protected stopperFnList: StopperFn[]
+  protected oaId: string
 
   get accessToken (): string {
     if (!this.accessTokenPayload) {
@@ -65,6 +70,9 @@ class OfficialAccount extends EventEmitter {
     super()
     log.verbose('OfficialAccount', 'constructor(%s)', JSON.stringify(options))
 
+    // keep the official account id consist with puppet-oa
+    this.oaId = `gh_${options.appId}`
+
     this.webhook = new Webhook({
       personalMode: !!this.options.personalMode,
       port: this.options.port,
@@ -72,7 +80,7 @@ class OfficialAccount extends EventEmitter {
       webhookProxyUrl: this.options.webhookProxyUrl,
     })
 
-    this.payloadStore  = new PayloadStore()
+    this.payloadStore = new PayloadStore()
     this.simpleUnirest = getSimpleUnirest('https://api.weixin.qq.com/cgi-bin/')
     this.stopperFnList = []
   }
@@ -146,8 +154,8 @@ class OfficialAccount extends EventEmitter {
      */
     const ret = await this.simpleUnirest
       .get<Partial<ErrorPayload> & {
-        access_token : string
-        expires_in   : number
+        access_token: string
+        expires_in: number
       }>(`token?grant_type=client_credential&appid=${this.options.appId}&secret=${this.options.appSecret}`)
 
     log.verbose('OfficialAccount', 'updateAccessToken() %s', JSON.stringify(ret.body))
@@ -171,9 +179,9 @@ class OfficialAccount extends EventEmitter {
     }
 
     this.accessTokenPayload = {
-      expiresIn : ret.body.expires_in,
-      timestamp : Date.now(),
-      token     : ret.body.access_token,
+      expiresIn: ret.body.expires_in,
+      timestamp: Date.now(),
+      token: ret.body.access_token,
     }
 
     log.verbose('OfficialAccount', 'updateAccessToken() synced. New token will expiredIn %s seconds',
@@ -215,11 +223,12 @@ class OfficialAccount extends EventEmitter {
   }
 
   async sendCustomMessagePersonal (args: {
-    touser  : string,
-    msgtype : OAMessageType,
-    content : string,
-  }) {
+    touser: string,
+    msgtype: OAMessageType,
+    content: string,
+  }): Promise<string> {
     this.webhook.emit('instantReply', args)
+    return 'default-custome-message-id'
   }
 
   /**
@@ -230,7 +239,7 @@ class OfficialAccount extends EventEmitter {
     touser: string,
     msgtype: OAMessageType,
     content: string,
-  }): Promise<ErrorPayload> {
+  }): Promise<string> {
     log.verbose('OfficialAccount', 'sendCustomMessage(%s)', JSON.stringify(args))
 
     const ret = await this.simpleUnirest
@@ -256,14 +265,27 @@ class OfficialAccount extends EventEmitter {
       }
      */
 
-    return ret.body
+    // save the official-account payload
+    if (ret.body.errcode) {
+      throw new Error(`OfficialAccount sendCustomMessage() can send message <${JSON.stringify(args)}>`)
+    }
+
+    const uuid: string = v4()
+    await this.payloadStore.setMessagePayload(uuid, {
+      CreateTime: getTimeStampString(),
+      FromUserName: this.oaId,
+      MsgId: uuid,
+      MsgType: 'text',
+      ToUserName: args.touser,
+    })
+    return uuid
   }
 
   async sendFile (args: {
     file: FileBox,
     touser: string,
     msgtype: OAMediaType
-  }): Promise<void> {
+  }): Promise<string> {
     log.verbose('OfficialAccount', 'sendFile(%s)', JSON.stringify(args))
 
     await args.file.ready()
@@ -278,10 +300,10 @@ class OfficialAccount extends EventEmitter {
     }
 
     const mediaResponse = await this.simpleUnirest.post<Partial<ErrorPayload> & {
-          media_id    : string,
-          created_at  : string,
-          type        : string,
-        }>(`media/upload?access_token=${this.accessToken}&type=${args.msgtype}`).attach('attachments[]', buf, info)
+      media_id: string,
+      created_at: string,
+      type: string,
+    }>(`media/upload?access_token=${this.accessToken}&type=${args.msgtype}`).attach('attachments[]', buf, info)
     // the type of result is string
     if (typeof mediaResponse.body === 'string') {
       mediaResponse.body = JSON.parse(mediaResponse.body)
@@ -298,7 +320,20 @@ class OfficialAccount extends EventEmitter {
     const messageResponse = await this.simpleUnirest.post<ErrorPayload>(`message/custom/send?access_token=${this.accessToken}`).type('json').send(data)
     if (messageResponse.body.errcode) {
       log.error('OfficialAccount', 'SendFile() can not send file to wechat user .<%s>', messageResponse.body.errmsg)
+      throw new Error(`OfficialAccount', 'SendFile() can not send file to wechat user .<${messageResponse.body.errmsg}>'`)
     }
+
+    // now only support uploading image
+    const messagePayload: OAMessagePayload = {
+      CreateTime: getTimeStampString(),
+      FromUserName: this.oaId,
+      MediaId: mediaResponse.body.media_id,
+      MsgId: v4(),
+      MsgType: 'image',
+      ToUserName: args.touser,
+    }
+    await this.payloadStore.setMessagePayload(messagePayload.MsgId, messagePayload)
+    return messagePayload.MsgId
   }
 
   async getContactList (): Promise<string[]> {
@@ -309,12 +344,12 @@ class OfficialAccount extends EventEmitter {
 
     while (true) {
       const req = await this.simpleUnirest.get<Partial<ErrorPayload> & {
-        total       : number,
-        count       : number,
-        data        : {
-          openid    : string[]
+        total: number,
+        count: number,
+        data: {
+          openid: string[]
         },
-        next_openid : string
+        next_openid: string
       }>(`user/get?access_token=${this.accessToken}&next_openid=${nextOpenId}`)
 
       if (req.body.errcode) {
@@ -339,23 +374,23 @@ class OfficialAccount extends EventEmitter {
       // wechaty load the SelfContact object, so just return it.
       /* eslint-disable sort-keys */
       const selfContactPayload: OAContactPayload = {
-        subscribe         : 0,
-        openid            : openId,
-        nickname          : 'from official-account options ?',
-        sex               : ContactGender.Unknown,
-        language          : 'zh_CN',
-        city              : '北京',
-        province          : '北京',
-        country           : '中国',
-        headimgurl        : '',
-        subscribe_time    : 0,
-        unionid           : '0',
-        remark            : '微信公众号客服',
-        groupid           : 0,
-        tagid_list        : [],
-        subscribe_scene   : '',
-        qr_scene          : 0,
-        qr_scene_str      : '',
+        subscribe: 0,
+        openid: openId,
+        nickname: 'from official-account options ?',
+        sex: ContactGender.Unknown,
+        language: 'zh_CN',
+        city: '北京',
+        province: '北京',
+        country: '中国',
+        headimgurl: '',
+        subscribe_time: 0,
+        unionid: '0',
+        remark: '微信公众号客服',
+        groupid: 0,
+        tagid_list: [],
+        subscribe_scene: '',
+        qr_scene: 0,
+        qr_scene_str: '',
       }
       return selfContactPayload
     }
@@ -396,6 +431,146 @@ class OfficialAccount extends EventEmitter {
 
     if (res.body.errcode) {
       log.error('OfficialAccount', 'setContactRemark() can update contact remark (%s)', res.body.errmsg)
+    }
+  }
+
+  async createTag (name: string): Promise<void | string> {
+    log.verbose('OfficialAccount', 'createTag(%s)', name)
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload> & {
+      tag?: {
+        id: string,
+      }
+    }>(`tags/create?access_token=${this.accessToken}`)
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'createTag(%s) error code : %s', name, res.body.errcode)
+    } else {
+      return res.body.tag?.id
+    }
+  }
+
+  async getTagList (): Promise<OATagPayload[]> {
+    log.verbose('OfficialAccount', 'getTagList()')
+
+    const res = await this.simpleUnirest.get<Partial<ErrorPayload> & {
+      tags?: OATagPayload[]
+    }>(`tags/get?access_token=${this.accessToken}`)
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'getTagList() error code : %s', res.body.errcode)
+      return []
+    }
+
+    if (!res.body.tags || res.body.tags.length === 0) {
+      log.warn('OfficialAccount', 'getTagList() get empty tag list')
+      return []
+    }
+    return res.body.tags
+  }
+
+  async deleteTag (tagId: number): Promise<void> {
+    log.verbose('OfficialAccount', 'deleteTag(%s)', tagId)
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload>>(`tags/delete?access_token=${this.accessToken}`).send({
+      tag: {
+        id: tagId,
+      },
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'deleteTag() error code : %s', res.body.errcode)
+    }
+  }
+
+  async addTagToMembers (tagId: number, openIdList: string[]): Promise<void> {
+    log.verbose('OfficialAccount', 'addTagToMembers(%s)', JSON.stringify({ tagId, openIdList }))
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload>>(`tags/members/batchtagging?access_token=${this.accessToken}`).send({
+      opeid_list: openIdList,
+      tag_id: tagId,
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'addTagToMembers() error code : %s', res.body.errcode)
+    }
+  }
+
+  async removeTagFromMembers (tagId: number, openIdList: string[]): Promise<void> {
+    log.verbose('OfficialAccount', 'removeTagFromMembers(%s)', JSON.stringify({ tagId, openIdList }))
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload>>(`tags/members/batchuntagging?access_token=${this.accessToken}`).send({
+      opeid_list: openIdList,
+      tag_id: tagId,
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'removeTagFromMembers() error code : %s', res.body.errcode)
+    }
+  }
+
+  async getMemberTag (openid: string): Promise<void> {
+    log.verbose('OfficialAccount', 'getMemberTag(%s)', openid)
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload> & {
+      tagid_list: number[]
+    }>(`tags/getidlist?access_token=${this.accessToken}`).send({
+      openid: openid,
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'deleteTag() error code : %s', res.body.errcode)
+    }
+  }
+
+  async setMemberRemark (openid: string, remark: string): Promise<void> {
+    log.verbose('OfficialAccount', 'setMemberRemark(%s)', openid)
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload>>(`user/info/updateremark?access_token=${this.accessToken}`).send({
+      openid: openid,
+      remark: remark,
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'deleteTag() error code : %s', res.body.errcode)
+    }
+  }
+
+  async sendBatchTextMessageByTagId (tagId: number, msg: string): Promise<void> {
+    log.verbose('OfficialAccount', 'sendBatchTextMessageByTagId(%s)', JSON.stringify({ tagId, msg }))
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload> & {
+      msg_id: number,
+      msg_data_id: number,
+    }>(`message/mass/sendall?access_token=${this.accessToken}`).send({
+      filter: {
+        is_to_all: false,
+        tag_id: tagId,
+      },
+      text: {
+        content: msg,
+      },
+      msgtype: 'text',
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'deleteTag() error code : %s', res.body.errcode)
+    }
+  }
+
+  async sendBatchTextMessageByOpenidList (openidList: string[], msg: string): Promise<void> {
+    log.verbose('OfficialAccount', 'sendBatchTextMessageByOpenidList(%s)', JSON.stringify({ openidList, msg }))
+
+    const res = await this.simpleUnirest.post<Partial<ErrorPayload> & {
+      msg_id: number,
+      msg_data_id: number,
+    }>(`message/mass/send?access_token=${this.accessToken}`).send({
+      touser: openidList,
+      msgtype: 'text',
+      text: { content: msg },
+    })
+
+    if (res.body.errcode) {
+      log.error('OfficialAccount', 'deleteTag() error code : %s', res.body.errcode)
     }
   }
 

--- a/src/official-account/payload-store.ts
+++ b/src/official-account/payload-store.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 import { log } from 'wechaty-puppet'
 
 import { FlashStore } from 'flash-store'
-import LRU from 'lru-cache'
+import LRU            from 'lru-cache'
 
 import {
   OAMessagePayload,
@@ -50,8 +50,8 @@ class PayloadStore {
       dispose (key: string, val: any) {
         log.silly('PayloadStore', `constructor() lruOptions.dispose(${key}, ${JSON.stringify(val)})`)
       },
-      max:    1000,
-      maxAge: 1000 * 60 * 60,
+      max    : 1000,
+      maxAge : 1000 * 60 * 60,
     }
 
     this.cacheOAMessagePayload = new LRU<string, OAMessagePayload>(lruOptions)

--- a/src/official-account/schema.ts
+++ b/src/official-account/schema.ts
@@ -11,35 +11,35 @@ export type OAMessageType = 'text'
 export type OAMediaType = 'image' | 'voice' | 'video' | 'thumb'
 
 export interface OAMessagePayload {
-  ToUserName  : string
-  FromUserName: string
-  CreateTime  : string
-  MsgType     : OAMessageType
-  MsgId       : string
-  Content?    : string
-  PicUrl?     : string
-  MediaId?    : string
+  ToUserName   : string
+  FromUserName : string
+  CreateTime   : string
+  MsgType      : OAMessageType
+  MsgId        : string
+  Content?     : string
+  PicUrl?      : string
+  MediaId?     : string
 }
 
 /* eslint-disable camelcase */
 export type OAContactPayload = Partial<ErrorPayload> & {
-  subscribe         : number,
-  openid            : string,
-  nickname          : string,
-  sex               : ContactGender,
-  language          : Language,
-  city              : string,
-  province          : string,
-  country           : string,
-  headimgurl        : string,
-  subscribe_time    : number,
-  unionid           : string,
-  remark            : string,
-  groupid           : number,
-  tagid_list        : Array<number>,
-  subscribe_scene   : string,
-  qr_scene          : number,
-  qr_scene_str      : string,
+  subscribe       : number,
+  openid          : string,
+  nickname        : string,
+  sex             : ContactGender,
+  language        : Language,
+  city            : string,
+  province        : string,
+  country         : string,
+  headimgurl      : string,
+  subscribe_time  : number,
+  unionid         : string,
+  remark          : string,
+  groupid         : number,
+  tagid_list      : Array<number>,
+  subscribe_scene : string,
+  qr_scene        : number,
+  qr_scene_str    : string,
 }
 
 export type Language = 'zh_CN' | 'zh_TW' | 'en'

--- a/src/official-account/schema.ts
+++ b/src/official-account/schema.ts
@@ -48,3 +48,9 @@ export interface ErrorPayload {
   errcode : number,
   errmsg  : string,
 }
+
+export interface OATagPayload {
+  id    : number,
+  name  : string,
+  count : number,
+}

--- a/src/official-account/utils.ts
+++ b/src/official-account/utils.ts
@@ -1,0 +1,7 @@
+export function getTimeStampString (): string {
+  let now: number = new Date().getTime()
+  if (now > 9999999999) {
+    now = Math.ceil(now / 1000)
+  }
+  return now.toString()
+}

--- a/src/official-account/webhook.ts
+++ b/src/official-account/webhook.ts
@@ -3,19 +3,21 @@ import express      from 'express'
 import xmlParser    from 'express-xml-bodyparser'
 import localtunnel  from 'localtunnel'
 
-import TypedEventEmitter from 'typed-emitter'
+import { log }            from 'wechaty-puppet'
+import { EventEmitter }   from 'events'
+import TypedEventEmitter  from 'typed-emitter'
 
-import { log } from 'wechaty-puppet'
-import { EventEmitter } from 'events'
-
-import { OAMessagePayload, OAMessageType }   from './schema'
+import {
+  OAMessagePayload,
+  OAMessageType,
+}     from './schema'
 
 const WebhookEventEmitter = EventEmitter as new () => TypedEventEmitter<{
   message: (message: OAMessagePayload) => void,
   instantReply: (message: {
-    touser: string,
-    msgtype: OAMessageType,
-    content: string,
+    touser  : string,
+    msgtype : OAMessageType,
+    content : string,
   }) => void,
 }>
 
@@ -27,18 +29,18 @@ export interface VerifyArgs {
 
 interface WebhookOptions {
   personalMode?    : boolean,
-  port?            : number
-  webhookProxyUrl? : string
-  verify           : (args: VerifyArgs) => boolean
+  port?            : number,
+  webhookProxyUrl? : string,
+  verify           : (args: VerifyArgs) => boolean,
 }
 
 class Webhook extends WebhookEventEmitter {
 
-  protected server? : http.Server
-  protected tunnel? : localtunnel.Tunnel
+  protected server?       : http.Server
+  protected tunnel?       : localtunnel.Tunnel
   protected personalMode? : boolean
   protected messageCache? : any = {}
-  protected userOpen? : any = {}
+  protected userOpen?     : any = {}
 
   public readonly webhookProxyHost?      : string
   public readonly webhookProxySchema?    : string
@@ -201,8 +203,8 @@ class Webhook extends WebhookEventEmitter {
   }
 
   async appGet (
-    req: express.Request,
-    res: express.Response,
+    req : express.Request,
+    res : express.Response,
   ): Promise<void> {
     log.verbose('Webhook', 'appGet({url: %s})', req.url)
 
@@ -227,8 +229,8 @@ class Webhook extends WebhookEventEmitter {
   }
 
   async appPost (
-    req: express.Request,
-    res: express.Response,
+    req : express.Request,
+    res : express.Response,
   ): Promise<void> {
     const payload = req.body.xml as OAMessagePayload
     log.verbose('Webhook', 'appPost({url: %s} with payload: %s',

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -44,17 +44,20 @@ import {
   PayloadType,
 }                           from 'wechaty-puppet'
 
-import { VERSION } from './version'
+import { VERSION }  from './version'
 import {
   qrCodeForChatie,
   envOptions,
-}                                   from './config'
+}                   from './config'
 
 import {
   OfficialAccountOptions,
   OfficialAccount,
-}                             from './official-account/official-account'
-import { OAContactPayload, OAMessagePayload } from './official-account/schema'
+}                   from './official-account/official-account'
+import {
+  OAContactPayload,
+  OAMessagePayload,
+}                   from './official-account/schema'
 
 export type PuppetOAOptions = PuppetOptions & Partial<OfficialAccountOptions>
 
@@ -84,7 +87,7 @@ class PuppetOA extends Puppet {
   protected webhookProxyUrl? : string
   protected personalMode?    : boolean
 
-  protected oa?: OfficialAccount
+  protected oa? : OfficialAccount
 
   constructor (
     options: PuppetOAOptions = {},

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -153,8 +153,10 @@ class PuppetOA extends Puppet {
       })
 
       // FIXME: Huan(202008) find a way to get the bot user information
+      // Official Account Info can be customized by user, so It should be
+      // configured by environment variable.
       // set gh_ prefix to identify the official-account
-      this.id = 'gh_wechaty-puppet-official-account'
+      this.id = `gh_${this.appId}`
       await this.oa.payloadStore.setContactPayload(this.id, { openid: this.id } as any)
 
       this.bridgeEvents(this.oa)
@@ -466,12 +468,12 @@ class PuppetOA extends Puppet {
   private async messageSend (
     conversationId: string,
     something: string | FileBox, // | Attachment
-  ): Promise<void> {
+  ): Promise<string> {
     log.verbose('PuppetOA', 'messageSend(%s, %s)', conversationId, something)
     if (!this.id) {
       throw new Error('no this.id')
     }
-
+    let msgId = null
     if (typeof something === 'string') {
       const payload = {
         content: something,
@@ -479,26 +481,33 @@ class PuppetOA extends Puppet {
         touser: conversationId,
       }
       if (this.personalMode) {
-        await this.oa?.sendCustomMessagePersonal(payload)
+        msgId = await this.oa?.sendCustomMessagePersonal(payload)
+        if (!msgId) {
+          throw new Error('can"t send personal CustomeMessage')
+        }
       } else {
-        await this.oa?.sendCustomMessage(payload)
+        msgId = await this.oa?.sendCustomMessage(payload)
       }
     } else if (something instanceof FileBox) {
       await this.oa?.sendFile({ file: something, msgtype: 'image', touser: conversationId })
     }
+    if (!msgId) {
+      throw new Error('PuppetOA messageSend() can"t get msgId response')
+    }
+    return msgId
   }
 
   public async messageSendText (
     conversationId: string,
     text     : string,
-  ): Promise<void> {
+  ): Promise<string> {
     return this.messageSend(conversationId, text)
   }
 
   public async messageSendFile (
     conversationId: string,
     file     : FileBox,
-  ): Promise<void> {
+  ): Promise<string> {
     return this.messageSend(conversationId, file)
   }
 


### PR DESCRIPTION
There are two improvements:
- add official-account interfaces which is useful for oa-puppet
- change `id` of pupept to `gh_{app_id}`

> `gh_` is the prefix of official-acount prefix. 