### PR TITLE
enable accessTokenProxyUrl feature to support dynamc ip address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-official-account",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "description": "Wechaty Puppet for WeChat Official Accounts",
   "directories": {
     "test": "tests"

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,13 +11,15 @@ function qrCodeForChatie (): FileBox {
 }
 
 function envOptions (): Partial<PuppetOAOptions> {
+  /* eslint-disable sort-keys */
   return {
-    appId           : process.env.WECHATY_PUPPET_OA_APP_ID,
-    appSecret       : process.env.WECHATY_PUPPET_OA_APP_SECRET,
-    personalMode    : !!process.env.WECHATY_PUPPET_OA_PERSONAL_MODE,
-    port            : process.env.WECHATY_PUPPET_OA_PORT ? parseInt(process.env.WECHATY_PUPPET_OA_PORT) : undefined,
-    token           : process.env.WECHATY_PUPPET_OA_TOKEN,
-    webhookProxyUrl : process.env.WECHATY_PUPPET_OA_WEBHOOK_PROXY_URL,
+    appId               : process.env.WECHATY_PUPPET_OA_APP_ID,
+    appSecret           : process.env.WECHATY_PUPPET_OA_APP_SECRET,
+    personalMode        : !!process.env.WECHATY_PUPPET_OA_PERSONAL_MODE,
+    port                : process.env.WECHATY_PUPPET_OA_PORT ? parseInt(process.env.WECHATY_PUPPET_OA_PORT) : undefined,
+    token               : process.env.WECHATY_PUPPET_OA_TOKEN,
+    webhookProxyUrl     : process.env.WECHATY_PUPPET_OA_WEBHOOK_PROXY_URL,
+    accessTokenProxyUrl : process.env.WECHATY_PUPPET_OA_ACCESS_TOKEN_PROXY,
   }
 }
 

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -87,6 +87,8 @@ class PuppetOA extends Puppet {
   protected webhookProxyUrl? : string
   protected personalMode?    : boolean
 
+  protected accessTokenProxyUrl? : string
+
   protected oa? : OfficialAccount
 
   constructor (
@@ -132,6 +134,20 @@ class PuppetOA extends Puppet {
 
     this.port            = options.port
     this.webhookProxyUrl = options.webhookProxyUrl
+
+    /**
+     * NOTE: if the ip address of server is dynamic, it can't fetch the accessToken from tencent server.
+     * So, the accessTokenProxyUrl configuration is needed to fetch the accessToken from the specific endpoint.
+     *
+     * eg: accessTokenProxyUrl = 'http://your-endpoint/'
+     * puppet-oa will fetch accessToken from: http://your-endpoint/token?grant_type=client_credential&appid=${appId}&secret=${appSecret}
+     */
+    if (options.accessTokenProxyUrl) {
+      if (options.accessTokenProxyUrl.endsWith('/')) {
+        options.accessTokenProxyUrl = options.accessTokenProxyUrl.substring(0, options.accessTokenProxyUrl.length - 1)
+      }
+      this.accessTokenProxyUrl = options.accessTokenProxyUrl
+    }
   }
 
   public async start (): Promise<void> {


### PR DESCRIPTION
## Situation

When you deploy the `puppet-official-account` in cluster server, and it will kill and start a docker in a new host. So, the ip address will change, and it can fetch `accessToken` from tencent server.  Because the tencent server require the ip address of the request must be in their white ip address which you can add a limited IP whitelist. But in this situation, you can't define the specific IP address. So, we should find a way to resolve it.

## limitation

> refer to:  [“获取access_token”接口新增IP白名单保护](https://mp.weixin.qq.com/cgi-bin/announce?action=getannouncement&key=1495617578&version=1&lang=zh_CN&platform=2&token=809234752)

There is a limit for `getAccessToken` method that the ip address of the request must be in their white ip address.

## Solution

We can configure the `accessTokenProxyUrl`  to fetch `accessToken` from a fix endpoint, which has a fix ip address. So, it will  fix the above problem in a simple way. 

## Usage

### 1. set envrioment or configuration

```shell
export WECHATY_PUPPET_OA_ACCESS_TOKEN_PROXY=http://your-endpoint/
```

or

```typescript
const puppetOaConfig: PuppetOAOptions = {
  appId: "",
  appSecret: "",
  token: "",
  accessTokenProxyUrl: "http://your-endpoint/"
}
const puppet = new PuppetOA(puppetOaConfig)
```

### 2. create your accessTokenProxyServer

You can create your `AccessTokenProxyServer` to help you fetch the accessToken and return it back to you. 

The final `getAccessToken` action will request: `http://your-endpoint/token?grant_type=client_credential&appid=${appId}&secret=${appSecret}`.

If you don't want to create your `AccessTokenProxyServer`, you can use the support docker to deploy your service: https://github.com/wj-Mcat/official-account-access-token-center