### PR TITLE
enable sending voice message through messageSendFile()

### DIFF
--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -299,9 +299,10 @@ class OfficialAccount extends EventEmitter {
   async sendFile (args: {
     file    : FileBox,
     touser  : string,
-    msgtype : OAMediaType
+    msgtype : OAMediaType,
   }): Promise<string> {
-    log.verbose('OfficialAccount', 'sendFile(%s)', JSON.stringify(args))
+    // log.verbose('OfficialAccount', 'sendFile(%s)', JSON.stringify(args))
+    // JSON.stringify does not support .mp3 filetype
 
     await args.file.ready()
     const { buf, info } = await normalizeFileBox(args.file)
@@ -310,6 +311,7 @@ class OfficialAccount extends EventEmitter {
     // and fetched fileBox has no name, which will cause error in upload file process.
     // this works for all of the image file
     // TODO -> should be improved later.
+
     if (args.file.type() === FileBoxType.Url && args.file.mimeType === 'image/jpeg') {
       info.filename = `${args.file.name}.jpeg`
     }
@@ -325,13 +327,14 @@ class OfficialAccount extends EventEmitter {
     }
 
     const data = {
-      image :
-      {
-        media_id : mediaResponse.body.media_id,
-      },
+      [args.msgtype] :
+        {
+          media_id : mediaResponse.body.media_id,
+        },
       msgtype : args.msgtype,
       touser  : args.touser,
-    }
+      }
+
     const messageResponse = await this.simpleUnirest.post<ErrorPayload>(`message/custom/send?access_token=${this.accessToken}`).type('json').send(data)
     if (messageResponse.body.errcode) {
       log.error('OfficialAccount', 'SendFile() can not send file to wechat user .<%s>', messageResponse.body.errmsg)

--- a/src/official-account/official-account.ts
+++ b/src/official-account/official-account.ts
@@ -301,7 +301,7 @@ class OfficialAccount extends EventEmitter {
     touser  : string,
     msgtype : OAMediaType,
   }): Promise<string> {
-    // log.verbose('OfficialAccount', 'sendFile(%s)', JSON.stringify(args))
+    log.verbose('OfficialAccount', 'sendFile(%s)', JSON.stringify(args))
     // JSON.stringify does not support .mp3 filetype
 
     await args.file.ready()
@@ -333,7 +333,7 @@ class OfficialAccount extends EventEmitter {
         },
       msgtype : args.msgtype,
       touser  : args.touser,
-      }
+    }
 
     const messageResponse = await this.simpleUnirest.post<ErrorPayload>(`message/custom/send?access_token=${this.accessToken}`).type('json').send(data)
     if (messageResponse.body.errcode) {

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -534,12 +534,12 @@ class PuppetOA extends Puppet {
   ): Promise<string> {
     let msgtype: OAMediaType 
     switch (file.mimeType) {
-      case 'image/jpeg': msgtype = 'image';
-        break;
-      case 'audio/mpeg': msgtype = 'voice';
-        break;
+      case 'image/jpeg': msgtype = 'image'
+        break
+      case 'audio/mpeg': msgtype = 'voice'
+        break
       default:
-        throw new Error('Media type not supported');
+        throw new Error('Media type not supported')
     }
     return this.messageSend(conversationId, file, msgtype)
   }

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -532,7 +532,15 @@ class PuppetOA extends Puppet {
     conversationId: string,
     file     : FileBox,
   ): Promise<string> {
-    const msgtype: OAMediaType = (file.mimeType === 'image/jpeg') ? 'image' : 'voice'
+    let msgtype: OAMediaType 
+    switch (file.mimeType) {
+      case 'image/jpeg': msgtype = 'image';
+        break;
+      case 'audio/mpeg': msgtype = 'voice';
+        break;
+      default:
+        throw new Error('Media type not supported');
+    }
     return this.messageSend(conversationId, file, msgtype)
   }
 

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -532,7 +532,7 @@ class PuppetOA extends Puppet {
     conversationId: string,
     file     : FileBox,
   ): Promise<string> {
-    let msgtype: OAMediaType 
+    let msgtype: OAMediaType
     switch (file.mimeType) {
       case 'image/jpeg': msgtype = 'image'
         break

--- a/src/puppet-oa.ts
+++ b/src/puppet-oa.ts
@@ -57,6 +57,7 @@ import {
 import {
   OAContactPayload,
   OAMessagePayload,
+  OAMediaType,
 }                   from './official-account/schema'
 
 export type PuppetOAOptions = PuppetOptions & Partial<OfficialAccountOptions>
@@ -152,7 +153,6 @@ class PuppetOA extends Puppet {
 
   public async start (): Promise<void> {
     log.verbose('PuppetOA', 'start()')
-
     if (this.state.on()) {
       log.warn('PuppetOA', 'start() is called on a ON puppet. await ready(on) and return.')
       await this.state.ready('on')
@@ -161,7 +161,6 @@ class PuppetOA extends Puppet {
 
     try {
       this.state.on('pending')
-
       this.oa = new OfficialAccount({
         appId           : this.appId,
         appSecret       : this.appSecret,
@@ -170,7 +169,6 @@ class PuppetOA extends Puppet {
         token           : this.token,
         webhookProxyUrl : this.webhookProxyUrl,
       })
-
       // FIXME: Huan(202008) find a way to get the bot user information
       // Official Account Info can be customized by user, so It should be
       // configured by environment variable.
@@ -179,9 +177,7 @@ class PuppetOA extends Puppet {
       await this.oa.payloadStore.setContactPayload(this.id, { openid: this.id } as any)
 
       this.bridgeEvents(this.oa)
-
       await this.oa.start()
-
       this.state.on(true)
     } catch (e) {
       log.error('PuppetOA', 'start() rejection: %s', e)
@@ -495,6 +491,7 @@ class PuppetOA extends Puppet {
   private async messageSend (
     conversationId: string,
     something: string | FileBox, // | Attachment
+    mediatype: OAMediaType = 'image'
   ): Promise<string> {
     log.verbose('PuppetOA', 'messageSend(%s, %s)', conversationId, something)
     if (!this.id) {
@@ -516,7 +513,7 @@ class PuppetOA extends Puppet {
         msgId = await this.oa?.sendCustomMessage(payload)
       }
     } else if (something instanceof FileBox) {
-      await this.oa?.sendFile({ file: something, msgtype: 'image', touser: conversationId })
+      await this.oa?.sendFile({ file: something, msgtype: mediatype, touser: conversationId })
     }
     if (!msgId) {
       throw new Error('PuppetOA messageSend() can"t get msgId response')
@@ -535,7 +532,8 @@ class PuppetOA extends Puppet {
     conversationId: string,
     file     : FileBox,
   ): Promise<string> {
-    return this.messageSend(conversationId, file)
+    const msgtype: OAMediaType = (file.mimeType === 'image/jpeg') ? 'image' : 'voice'
+    return this.messageSend(conversationId, file, msgtype)
   }
 
   public async messageSendContact (


### PR DESCRIPTION
Support sending amr/mp3 files through messageSendFile(), will check the mimetype of the Filebox file, and correspondingly adjust the request header sent to wechat OA server. 

Test plan:

    let fileBox_audio = FileBox.fromFile('xxx.mp3')
    if (msgPayload.fromId){
      await puppet.messageSendFile(msgPayload.fromId!, fileBox_audio)
    }  

Anticipated result: user should receive a voice message (recorded in 'xxx.mp3') from the wechat OA.

Link to https://github.com/wechaty/wechaty-puppet-official-account/issues/19